### PR TITLE
Feature/vj 726 azure app config

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: htg-qa-strapi-app
+  AZURE_WEBAPP_RG: htg-qa-strapi-rg  
   REGISTRY_LOGIN_SERVER: htgqaregistry.azurecr.io
 
 jobs:
@@ -20,6 +21,9 @@ jobs:
           uses: azure/login@v1
           with:
             creds: ${{ secrets.AZURE_QA_CREDENTIALS }}
+        - run: |
+            ./AppSettingsLoad.ps1 '${{ env.AZURE_WEBAPP_NAME }}' '${{ env.AZURE_WEBAPP_RG }}'
+          shell: pwsh            
         
         - name: 'Build and push image'
           uses: azure/docker-login@v1

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -14,6 +14,11 @@ jobs:
         # checkout the repo
         - name: 'Checkout GitHub Action'
           uses: actions/checkout@main
+        
+        - task: PowerShell@2
+          inputs:
+            targetType: 'filePath'
+            filePath: $(System.DefaultWorkingDirectory)\AppSettingsLoad.ps1
           
         - name: 'Login via Azure CLI'
           uses: azure/login@v1

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: htg-dev-strapi-app
+  AZURE_WEBAPP_RG: htg-dev-strapi-rg
   REGISTRY_LOGIN_SERVER: htgdevregistry.azurecr.io
 
 jobs:
@@ -20,7 +21,7 @@ jobs:
           with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
         - run: |
-            ./AppSettingsLoad.ps1 ${{ env.AppConfig }}
+            ./AppSettingsLoad.ps1 '${{ env.AZURE_WEBAPP_NAME }}' '${{ env.AZURE_WEBAPP_RG }}'
           shell: pwsh           
         
         - name: 'Build and push image'

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -14,17 +14,14 @@ jobs:
         # checkout the repo
         - name: 'Checkout GitHub Action'
           uses: actions/checkout@main
-        
-        - name: 'AppSettingsLoad'
-          uses: PowerShell@2
-          with:
-            targetType: 'filePath'
-            filePath: $(System.DefaultWorkingDirectory)\AppSettingsLoad.ps1
-
+                
         - name: 'Login via Azure CLI'
           uses: azure/login@v1
           with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
+        - run: |
+            ./AppSettingsLoad.ps1
+          shell: pwsh           
         
         - name: 'Build and push image'
           uses: azure/docker-login@v1

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -15,11 +15,12 @@ jobs:
         - name: 'Checkout GitHub Action'
           uses: actions/checkout@main
         
-        - task: PowerShell@2
-          inputs:
+        - name: 'AppSettingsLoad'
+          uses: PowerShell@2
+          with:
             targetType: 'filePath'
             filePath: $(System.DefaultWorkingDirectory)\AppSettingsLoad.ps1
-          
+
         - name: 'Login via Azure CLI'
           uses: azure/login@v1
           with:

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -20,7 +20,7 @@ jobs:
           with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
         - run: |
-            ./AppSettingsLoad.ps1
+            ./AppSettingsLoad.ps1 ${{ env.AppConfig }}
           shell: pwsh           
         
         - name: 'Build and push image'

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -22,7 +22,7 @@ jobs:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
         - run: |
             ./AppSettingsLoad.ps1 '${{ env.AZURE_WEBAPP_NAME }}' '${{ env.AZURE_WEBAPP_RG }}'
-          shell: pwsh           
+          shell: pwsh
         
         - name: 'Build and push image'
           uses: azure/docker-login@v1

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: htg-prod-strapi-app
+  AZURE_WEBAPP_RG: htg-prod-strapi-rg  
   REGISTRY_LOGIN_SERVER: htgprodregistry.azurecr.io
 
 jobs:
@@ -21,6 +22,9 @@ jobs:
           uses: azure/login@v1
           with:
             creds: ${{ secrets.AZURE_PROD_CREDENTIALS }}
+        - run: |
+            ./AppSettingsLoad.ps1 '${{ env.AZURE_WEBAPP_NAME }}' '${{ env.AZURE_WEBAPP_RG }}'
+          shell: pwsh            
         
         - name: 'Build and push image'
           uses: azure/docker-login@v1

--- a/.github/workflows/deploy-to-uat-dr.yml
+++ b/.github/workflows/deploy-to-uat-dr.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: htg-druat-strapi-app
+  AZURE_WEBAPP_RG: htg-druat-strapi-rg  
   REGISTRY_LOGIN_SERVER: htgdruatregistry.azurecr.io
 
 jobs:
@@ -21,6 +22,9 @@ jobs:
           uses: azure/login@v1
           with:
             creds: ${{ secrets.AZURE_UAT_CREDENTIALS }}
+        - run: |
+            ./AppSettingsLoad.ps1 '${{ env.AZURE_WEBAPP_NAME }}' '${{ env.AZURE_WEBAPP_RG }}'
+          shell: pwsh            
         
         - name: 'Build and push image'
           uses: azure/docker-login@v1

--- a/.github/workflows/deploy-to-uat.yml
+++ b/.github/workflows/deploy-to-uat.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: htg-uat-strapi-app
+  AZURE_WEBAPP_RG: htg-uat-strapi-rg  
   REGISTRY_LOGIN_SERVER: htguatregistry.azurecr.io
 
 jobs:
@@ -20,6 +21,9 @@ jobs:
           uses: azure/login@v1
           with:
             creds: ${{ secrets.AZURE_UAT_CREDENTIALS }}
+        - run: |
+            ./AppSettingsLoad.ps1 '${{ env.AZURE_WEBAPP_NAME }}' '${{ env.AZURE_WEBAPP_RG }}'
+          shell: pwsh            
         
         - name: 'Build and push image'
           uses: azure/docker-login@v1

--- a/AppSettingsLoad.ps1
+++ b/AppSettingsLoad.ps1
@@ -1,0 +1,26 @@
+
+Write-Output "------------  AppSettingsLoad.ps1 ---------------"
+
+Write-Output "AppConfig: $($Env:AppConfig)"
+
+$expression = "& az appconfig kv list --connection-string ""$Env:AppConfig"""
+$Output = Invoke-Expression $expression
+$settings = $Output | ConvertFrom-Json
+Write-Output "settings: $($settings.length)"
+
+# $pathConfig = "D:\Solutions\Production\BEIS\HelpToGrow\htg-cms\config\database.js"
+$pathConfig = "$(Build.SourcesDirectory)\config\database.js"
+Write-Output "pathConfig: $pathConfig"
+
+$content = Get-Content -Path $pathConfig
+Write-Output "Config length: $($content.Length)"
+
+for($i=0; $i -lt $settings.length; $i++)
+{    
+    $content = $content -replace "{{$($settings[$i].key)}}", $settings[$i].value
+    Write-Output "Replacing {{$($settings[$i].key)}}"
+}
+
+$content | Set-Content -Path $pathConfig
+
+Write-Output "---------------------------------------"

--- a/AppSettingsLoad.ps1
+++ b/AppSettingsLoad.ps1
@@ -1,14 +1,19 @@
-param([string]$AppConfig="") 
+param([string]$webApp="", [string]$resourceGroup="") 
+
 Write-Output "------------  AppSettingsLoad.ps1 ---------------"
 
-Write-Output "AppConfig: $AppConfig"
+$expression = "& az webapp config connection-string list --name ""$webApp"" --resource-group ""$resourceGroup"""
+$Output = Invoke-Expression $expression
+$connectionStrings = $Output | ConvertFrom-Json
+Write-Output "connectionStrings: $($connectionStrings.length)"
 
-$expression = "& az appconfig kv list --connection-string ""$AppConfig"""
+$connectionString = $connectionStrings | Where-Object { $_.name -eq "AppConfig" } | Select-Object -First 1
+
+$expression = "& az appconfig kv list --connection-string ""$($connectionString.value)"""
 $Output = Invoke-Expression $expression
 $settings = $Output | ConvertFrom-Json
 Write-Output "settings: $($settings.length)"
 
-# $pathConfig = "D:\Solutions\Production\BEIS\HelpToGrow\htg-cms\config\database.js"
 $pathConfig = ".\config\database.js"
 Write-Output "pathConfig: $pathConfig"
 

--- a/AppSettingsLoad.ps1
+++ b/AppSettingsLoad.ps1
@@ -9,7 +9,7 @@ $settings = $Output | ConvertFrom-Json
 Write-Output "settings: $($settings.length)"
 
 # $pathConfig = "D:\Solutions\Production\BEIS\HelpToGrow\htg-cms\config\database.js"
-$pathConfig = "$(Build.SourcesDirectory)\config\database.js"
+$pathConfig = ".\config\database.js"
 Write-Output "pathConfig: $pathConfig"
 
 $content = Get-Content -Path $pathConfig

--- a/AppSettingsLoad.ps1
+++ b/AppSettingsLoad.ps1
@@ -1,9 +1,9 @@
-
+param([string]$AppConfig="") 
 Write-Output "------------  AppSettingsLoad.ps1 ---------------"
 
-Write-Output "AppConfig: $($Env:AppConfig)"
+Write-Output "AppConfig: $AppConfig"
 
-$expression = "& az appconfig kv list --connection-string ""$Env:AppConfig"""
+$expression = "& az appconfig kv list --connection-string ""$AppConfig"""
 $Output = Invoke-Expression $expression
 $settings = $Output | ConvertFrom-Json
 Write-Output "settings: $($settings.length)"

--- a/config/database.js
+++ b/config/database.js
@@ -1,18 +1,18 @@
-module.exports = () => ({
+module.exports = ({env}) => ({
   defaultConnection: 'default',
   connections: {
     default: {
       connector: 'bookshelf',
       settings: {
-        client: 'postgres',
-        host: process.env.DATABASE_HOST,
-        port: process.env.DATABASE_PORT,
-        database: process.env.DATABASE_NAME,
-        username: process.env.DATABASE_USERNAME,
-        password: process.env.DATABASE_PASSWORD,
+        client: '{{DATABASE_CLIENT}}',
+        host: '{{DATABASE_HOST}}',
+        port: {{DATABASE_PORT}},
+        database: '{{DATABASE_NAME}}',
+        username: '{{DATABASE_USERNAME}}',
+        password: '{{DATABASE_PASSWORD}}',
         schema: 'public',
         ssl: false,
-      },
+      },      
       options: {},
     },
   },

--- a/config/database.js
+++ b/config/database.js
@@ -1,4 +1,4 @@
-module.exports = ({env}) => ({
+module.exports = () => ({
   defaultConnection: 'default',
   connections: {
     default: {
@@ -12,7 +12,7 @@ module.exports = ({env}) => ({
         password: '{{DATABASE_PASSWORD}}',
         schema: 'public',
         ssl: false,
-      },      
+      },
       options: {},
     },
   },


### PR DESCRIPTION
Proposed solution for solving issue in strapi - we can connect to Azure appsettings fine using the nodejs package - however the database.js configuration file is read as an object very early in the strapi app startup - and calling async/await js here throws errors - not been able to find a solution to this as it is tied directly to how the Strapi modules (core source) reads the settings files.

Proposed solution is a powershell script that during the build process - connects to Azure for webapp settings, gets the connectionstring to Azure App Configuration - then does a replace of all {{KEY}} in the database.js.
Could be extended to other files if required later.

![image](https://user-images.githubusercontent.com/95475775/177325061-f2a7e2e6-75ce-44e4-ae65-b4184b77dcc1.png)

